### PR TITLE
Remove bisect etc when installing the libraries

### DIFF
--- a/packages/mirage-block-volume/mirage-block-volume.2.0.0/opam
+++ b/packages/mirage-block-volume/mirage-block-volume.2.0.0/opam
@@ -5,6 +5,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
+  [make "release"]
   [make "all"]
   [make "install"]
 ]

--- a/packages/mirage-block-volume/mirage-block-volume.2.0.0/opam
+++ b/packages/mirage-block-volume/mirage-block-volume.2.0.0/opam
@@ -9,7 +9,10 @@ build: [
   [make "all"]
   [make "install"]
 ]
-remove: [["ocamlfind" "remove" "lvm"]]
+remove: [
+  ["ocamlfind" "remove" "lvm"]
+  ["ocamlfind" "remove" "lvm_internal"]
+]
 depends: [
   "cstruct" {>= "0.7.1"}
   "camldm" {>= "2.0.0"}

--- a/packages/shared-block-ring/shared-block-ring.2.0.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.0.0/opam
@@ -5,6 +5,7 @@ tags: [
   "org:xapi-project"
 ]
 build: [
+  [make "release"]
   [make "all"]
   [make "install"]
 ]


### PR DESCRIPTION
If we leave bisect linked in, then downstream client programs using bisect will fail to find the source of the library. Treat these development packages as releases.