### PR TITLE
shared-block-ring: depend on ipaddr to get mirage-types V1_LWT

### DIFF
--- a/packages/shared-block-ring/shared-block-ring.2.0.0/opam
+++ b/packages/shared-block-ring/shared-block-ring.2.0.0/opam
@@ -15,6 +15,7 @@ depends: [
   "ocamlfind"
   "ounit"
   "mirage-types"
+  "ipaddr"
   "mirage-block-unix"
   "sexplib"
   "io-page"


### PR DESCRIPTION
Signed-off-by: David Scott <dave.scott@citrix.com>